### PR TITLE
Allow loading files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "tslint \"**/*.ts\" -e \"out/**\"",
     "build": "webpack",
     "prod": "webpack -p",
-    "watch": "webpack-dev-server && open localhost:8080",
+    "watch": "echo '\n\n--- open localhost:8080 in your browser ---\n\n' && webpack-dev-server",
     "test": "tsc --outDir outtest && blue-tape outtest/test/*.js | tap-dot"
   },
   "repository": {
@@ -27,10 +27,13 @@
   "devDependencies": {
     "@types/blue-tape": "^0.1.30",
     "blue-tape": "^1.0.0",
+    "file-loader": "^0.9.0",
+    "raw-loader": "^0.5.1",
     "tap-dot": "^1.0.5",
     "ts-loader": "^0.8.2",
     "tslint": "^3.15.1",
     "typescript": "^2.0.3",
+    "url-loader": "^0.5.7",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.16.1"
   }


### PR DESCRIPTION
This should make `require('./images/file.png')` work; I had assumed webpack had the `url` and `raw` loaders built-in, but apparently not.

Also, `open` only works on OS X, so replace it with something cross-platform.
