### PR TITLE
Allow using node modules from electron

### DIFF
--- a/src/electron-modules.ts
+++ b/src/electron-modules.ts
@@ -1,0 +1,39 @@
+// This file is a dirty hack that is necessary because nobody expected anyone
+// to make an app that runs both in the browser and electron.
+
+// To add another electron-exclusive module, add it to this file,
+// and add it to 'externals' for non-webpack in webpack.config.js
+
+// if we're on the web, we define these objects to be null
+// they will ERROR AT RUNTIME if used
+// only use them if you've made sure that process.env.ELECTRON === true
+
+// ambient webpack function: creates modules
+declare function define(...args: any[]);
+
+// only define if non-browser
+if (!process.env.ELECTRON) {
+  define('electron', [], () => null);
+  define('os', [], () => null);
+  define('fs', [], () => null);
+  define('child_process', [], () => null);
+}
+
+// in electron, actually imports
+// in browser, imports null
+import * as _electron from 'electron';
+import * as _os from 'os';
+import * as _fs from 'fs';
+import * as _child_process from 'child_process';
+
+export var electron = _electron;
+export var os = _os;
+export var fs = _fs;
+export var child_process = _child_process;
+
+export default {
+  electron: _electron,
+  os: _os,
+  fs: _fs,
+  child_process: _child_process
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,13 @@ module.exports = function(env) {
         new webpack.DefinePlugin({
           'process.env.ELECTRON': false
         })
-      ]
+      ],
+      externals: {
+        'electron': 'electron',
+        'os': 'os',
+        'fs': 'fs',
+        'child_process': 'child_process'
+      }
     });
   }
 


### PR DESCRIPTION
If you want to use, say, 'fs' from node, you can do:

```ts
import fs from './electron-modules';

if (process.env.ELECTRON) {
  fs.mkdir('/bananas');
}
```

Make sure that the module you want is in webpack.config.js and electron-modules.ts, because this is actually a terrible hack.