### PR TITLE
Health bars stay on the screen #59

### DIFF
--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -171,7 +171,8 @@ export default class Renderer {
       }
       this.drawCircleBot(x, y, radius);
       this.drawImage(img, x, y, radius);
-      this.drawHealthBar(x, y, radius, healths[i], maxHealths[i]);
+      this.drawHealthBar(x, y, radius, healths[i], maxHealths[i],
+        world.minCorner, world.maxCorner);
     }
 
     if (realXs && realYs) {
@@ -207,11 +208,17 @@ export default class Renderer {
    * radius, health, and maxHealth
    */
   private drawHealthBar(xRobot: number, yRobot: number, radius: number,
-    health: number, maxHealth: number) {
+    health: number, maxHealth: number, minCorner: Victor, maxCorner: Victor) {
     if (!this.conf.healthBars) return; // skip if the option is turned off
 
     let x = xRobot - cst.HEALTH_BAR_WIDTH_HALF;
     let y = yRobot + radius;
+
+    let minX = minCorner.x;
+    let maxX = maxCorner.x - cst.HEALTH_BAR_WIDTH;
+    let maxY = maxCorner.y - cst.HEALTH_BAR_HEIGHT;
+    x = Math.max(minX, Math.min(x, maxX));
+    y = Math.min(maxY, y);
 
     this.ctx.fillStyle = "green"; // current health
     this.ctx.fillRect(x, y, cst.HEALTH_BAR_WIDTH * health / maxHealth,


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7017404/21756440/61101094-d5ef-11e6-8722-c3e1b0a62349.png)

The health bars are just pushed up a little so they don't go offscreen. Also stays on the screen if they move too left or too right, but I don't think that happens.