### PR TITLE
Remove antialiasing from MapEditor, fixes #71

### DIFF
--- a/src/mapeditor/renderer.ts
+++ b/src/mapeditor/renderer.ts
@@ -55,8 +55,7 @@ export default class MapRenderer {
     } else {
       this.ctx = ctx;
     }
-
-    this.ctx['imageSmoothingEnabled'] = false;
+    
     this.bgPattern = this.ctx.createPattern(imgs.background, 'repeat');
   }
 
@@ -193,6 +192,7 @@ export default class MapRenderer {
    * Draws an image centered at (x, y) with the given radius
    */
   private drawImage(img: HTMLImageElement, x: number, y: number, radius: number) {
+    this.ctx['imageSmoothingEnabled'] = false;
     this.ctx.drawImage(img, x-radius, y-radius, radius*2, radius*2);
   }
 }


### PR DESCRIPTION
Not sure why the original fix does not save the state of the `imageSmoothingEnabled` property, but adding the property before a draw does the trick.